### PR TITLE
Added ability to use session by passing its ID

### DIFF
--- a/src/SessionInstance.php
+++ b/src/SessionInstance.php
@@ -25,6 +25,11 @@ class SessionInstance implements SessionInterface
     protected $data = [];
 
     /**
+     * @var string The session ID
+     */
+    private $id = "";
+
+    /**
      * @var Cookie $cookie The cookie settings to use.
      */
     private $cookie;
@@ -35,8 +40,9 @@ class SessionInstance implements SessionInterface
      *
      * @param string $name The name of the session
      * @param Cookie $cookie The cookie settings to use
+     * @param string $id The session ID to use
      */
-    public function __construct($name, Cookie $cookie = null)
+    public function __construct($name, Cookie $cookie = null, $id = "")
     {
         if (strlen($name) < 1) {
             throw new \InvalidArgumentException("Cannot start session, no name has been specified");
@@ -48,6 +54,7 @@ class SessionInstance implements SessionInterface
 
         $this->name = $name;
         $this->cookie = $cookie;
+        $this->id = $id;
     }
 
 
@@ -69,6 +76,10 @@ class SessionInstance implements SessionInterface
 
         session_name($this->name);
 
+        if ($this->id !== "") {
+            session_id($this->id);
+        }
+
         session_start();
 
         /**
@@ -83,8 +94,24 @@ class SessionInstance implements SessionInterface
         # Grab the sessions data to respond to get()
         $this->data = $_SESSION;
 
+        # Grab session ID
+        $this->id = session_id();
+
         # Remove the lock from the session file
         session_write_close();
+    }
+
+
+    /**
+     * Get the session ID.
+     *
+     * @return string
+     */
+    public function getId()
+    {
+        $this->init();
+
+        return $this->id;
     }
 
 

--- a/tests/WebTest.php
+++ b/tests/WebTest.php
@@ -3,6 +3,7 @@
 namespace duncan3dc\SessionsTest;
 
 use duncan3dc\ObjectIntruder\Intruder;
+use duncan3dc\Sessions\SessionInstance;
 use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\FileCookieJar;
 
@@ -13,6 +14,8 @@ class WebTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        session_set_save_handler(new \SessionHandler);
+
         $path = tempnam(sys_get_temp_dir(), "duncan3dc-sessions-");
         $this->cookies = new FileCookieJar($path);
 
@@ -185,6 +188,17 @@ class WebTest extends \PHPUnit_Framework_TestCase
     {
         $this->request("cookies.php?httponly=1");
         $this->assertEquals(true, $this->getCookie()->getHttpOnly());
+    }
+
+
+    public function testSessionIDReuse()
+    {
+        $response = $this->request("use-id.php?session_name=web-sockets&key=using&value=ID");
+        $id = (string) $response->getBody();
+
+        # Ensure that we can retrieve values here that were set via the web browser
+        $session = new SessionInstance("web-sockets", null, $id);
+        $this->assertEquals("ID", $session->get("using"));
     }
 
 

--- a/tests/web/use-id.php
+++ b/tests/web/use-id.php
@@ -1,0 +1,7 @@
+<?php
+
+require __DIR__ . "/bootstrap.php";
+
+$session->set($_GET["key"], $_GET["value"]);
+
+echo $session->getId();


### PR DESCRIPTION
Allow to make and use Session object by passing session ID :
```
$session = new SessionInstance('name', null, 'sessionID');
```
And session ID can be obtained by :
```
$session->getSessionID();
```

This is a great feature to use sessions between HTTP server apps and non-HTTP server apps (WebSocket).