### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,9 @@ matrix:
   allow_failures:
   - php: nightly
 
-env:
-  - COMPOSER_OPTS=""
-  - COMPOSER_OPTS="--prefer-lowest"
-
 install:
   - composer self-update --snapshot
-  - composer update $COMPOSER_OPTS
+  - composer update -n
 
 script:
   - vendor/bin/phpunit --stderr --coverage-clover=clover.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,13 @@ matrix:
   allow_failures:
   - php: nightly
 
+env:
+  - COMPOSER_OPTS=""
+  - COMPOSER_OPTS="--prefer-lowest"
+
 install:
   - composer self-update --snapshot
-  - composer update -n
+  - composer update $COMPOSER_OPTS
 
 script:
   - vendor/bin/phpunit --stderr --coverage-clover=clover.xml

--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,14 @@
     }],
     "require": {
         "ext-session": "*",
-        "php": ">=5.6"
+        "php": "^5.6|^7.0"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^6.3",
         "mockery/mockery": "^1.0",
         "duncan3dc/object-intruder": "^0.3.0",
         "php-coveralls/php-coveralls": "^2.0",
-        "phpunit/phpunit": "^5.7|^6.5"
+        "phpunit/phpunit": "^5.7"
     },
     "autoload": {
         "psr-4": {"duncan3dc\\Sessions\\": "src/"}

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "mockery/mockery": "^1.0",
         "duncan3dc/object-intruder": "^0.3.0",
         "php-coveralls/php-coveralls": "^2.0",
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^5.7.11"
     },
     "autoload": {
         "psr-4": {"duncan3dc\\Sessions\\": "src/"}

--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,14 @@
     }],
     "require": {
         "ext-session": "*",
-        "php": "^5.6|^7.0"
+        "php": ">=5.6"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^6.3",
         "mockery/mockery": "^1.0",
         "duncan3dc/object-intruder": "^0.3.0",
         "php-coveralls/php-coveralls": "^2.0",
-        "phpunit/phpunit": "^5.7.11"
+        "phpunit/phpunit": "^5.7|^6.5"
     },
     "autoload": {
         "psr-4": {"duncan3dc\\Sessions\\": "src/"}

--- a/tests/CookieTest.php
+++ b/tests/CookieTest.php
@@ -4,8 +4,9 @@ namespace duncan3dc\SessionsTest;
 
 use duncan3dc\Sessions\Cookie;
 use function session_set_cookie_params;
+use PHPUnit\Framework\TestCase;
 
-class CookieTest extends \PHPUnit_Framework_TestCase
+class CookieTest extends TestCase
 {
 
     public function testGetLifetime()

--- a/tests/SessionInstanceTest.php
+++ b/tests/SessionInstanceTest.php
@@ -67,6 +67,14 @@ class SessionInstanceTest extends TestCase
     }
 
 
+    public function testRegenerate()
+    {
+        $originalId = session_id();
+        $result = $this->session->regenerate();
+        $this->assertNotSame($originalId, $result);
+    }
+
+
     public function testSerialize()
     {
         $obj = new \stdClass;

--- a/tests/SessionInstanceTest.php
+++ b/tests/SessionInstanceTest.php
@@ -4,8 +4,9 @@ namespace duncan3dc\SessionsTest;
 
 use duncan3dc\Sessions\SessionInstance;
 use function session_set_save_handler;
+use PHPUnit\Framework\TestCase;
 
-class SessionInstanceTest extends \PHPUnit_Framework_TestCase
+class SessionInstanceTest extends TestCase
 {
     protected $session;
 
@@ -16,9 +17,12 @@ class SessionInstanceTest extends \PHPUnit_Framework_TestCase
     }
 
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Cannot start session, no name has been specified
+     */
     public function testConstructor()
     {
-        $this->setExpectedException(\InvalidArgumentException::class, "Cannot start session, no name has been specified");
         new SessionInstance("");
     }
 

--- a/tests/SessionNamespaceTest.php
+++ b/tests/SessionNamespaceTest.php
@@ -5,8 +5,9 @@ namespace duncan3dc\SessionsTest;
 use duncan3dc\Sessions\SessionNamespace;
 use duncan3dc\Sessions\SessionInstance;
 use Mockery;
+use PHPUnit\Framework\TestCase;
 
-class SessionNamespaceTest extends \PHPUnit_Framework_TestCase
+class SessionNamespaceTest extends TestCase
 {
     protected $session;
     protected $namespace;

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -8,8 +8,9 @@ use duncan3dc\Sessions\SessionInterface;
 use Mockery;
 use function session_name;
 use function substr;
+use PHPUnit\Framework\TestCase;
 
-class SessionTest extends \PHPUnit_Framework_TestCase
+class SessionTest extends TestCase
 {
     /**
      * @var Mockery $session A SessionInstance to use for testing.
@@ -86,7 +87,8 @@ class SessionTest extends \PHPUnit_Framework_TestCase
     public function testSetString()
     {
         $this->session->shouldReceive("set")->once()->with("one", "1");
-        Session::set("one", "1");
+        $result = Session::set("one", "1");
+        $this->assertNull($result);
     }
 
 

--- a/tests/WebTest.php
+++ b/tests/WebTest.php
@@ -18,8 +18,9 @@ use function tempnam;
 use function time;
 use function unlink;
 use function unserialize;
+use PHPUnit\Framework\TestCase;
 
-class WebTest extends \PHPUnit_Framework_TestCase
+class WebTest extends TestCase
 {
     const SERVER_PORT = 15377;
     private static $pid;


### PR DESCRIPTION
# Changed log

- add ```php-7.2``` test.
- use the PHPUnit version ```^6.5``` to support the ```php-7.2``` test.
- use the class-based PHPUnit namespace.
- remove Composer ```prefer-lowest``` option to avoid installing the lower PHPUnit version.
- add the ```regenerate``` test.